### PR TITLE
TASK: Split each NodeType into a separate file

### DIFF
--- a/Configuration/NodeTypes.HideSeo.yaml
+++ b/Configuration/NodeTypes.HideSeo.yaml
@@ -1,11 +1,3 @@
-'Carbon.Navigation:NotInMenu':
-  abstract: true
-  properties:
-    _hiddenInIndex:
-      ui:
-        inspector:
-          group: hidden
-
 'Carbon.Navigation:HideSeo':
   abstract: true
   superTypes:

--- a/Configuration/NodeTypes.NotInMenu.yaml
+++ b/Configuration/NodeTypes.NotInMenu.yaml
@@ -1,0 +1,7 @@
+'Carbon.Navigation:NotInMenu':
+  abstract: true
+  properties:
+    _hiddenInIndex:
+      ui:
+        inspector:
+          group: hidden

--- a/Configuration/NodeTypes.RedirectToFirstChildPage.yaml
+++ b/Configuration/NodeTypes.RedirectToFirstChildPage.yaml
@@ -1,13 +1,3 @@
-'Carbon.Navigation:RedirectToParentPage':
-  abstract: true
-  search:
-    fulltext:
-      enable: false
-  superTypes:
-    'Carbon.Navigation:NotInMenu': true
-    'Carbon.Navigation:HideSeo': true
-    'Jonnitto.Sitemap:RemoveFromSitemap': true
-
 'Carbon.Navigation:RedirectToFirstChildPage':
   abstract: true
   search:

--- a/Configuration/NodeTypes.RedirectToParentPage.yaml
+++ b/Configuration/NodeTypes.RedirectToParentPage.yaml
@@ -1,0 +1,9 @@
+'Carbon.Navigation:RedirectToParentPage':
+  abstract: true
+  search:
+    fulltext:
+      enable: false
+  superTypes:
+    'Carbon.Navigation:NotInMenu': true
+    'Carbon.Navigation:HideSeo': true
+    'Jonnitto.Sitemap:RemoveFromSitemap': true


### PR DESCRIPTION
Current best practice is to separate each node type into a separate file. Makes searching node types based on editor file search easier as well.