### PR TITLE
:recylce: Version 3

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,10 +9,57 @@ Neos:
       autoInclude:
         Carbon.Navigation: true
 
+# You don't need to set values to false,
+# just don't write the key
+# The possible keys for renderClass are:
+#
+# renderClass:
+#   list:
+#     entryLevel: true || false
+#     menuLevel: true || false
+#   element:
+#     entryLevel: true || false
+#     menuLevel: true || false
+#     state:
+#       normal: string || array || false
+#       active: string || array || false
+#       current: string || array || false
+#     subpages: true
+#     isFirst: true || false
+#     isLast: true || false
+#   link:
+#     entryLevel: true || false
+#     menuLevel: true || false
+#     state:
+#       normal: string || array || false
+#       active: string || array || false
+#       current: string || array || false
+#     subpages: true || false
+#     isFirst: true || false
+#     isLast: true || false
+#     type: true || false
+#
+# In the dimension menu you got these additional values:
+#
+# renderClass:
+#   element:
+#     dimension:
+#       key: true || false
+#       value: true || false
+#     state:
+#       absent: string || array || false
+#   link:
+#     dimension:
+#       key: true || false
+#       value: true || false
+#     state:
+#       absent: string || array || false
+
+
 Carbon:
   Navigation:
     templatePath: 'resource://Carbon.Navigation/Private/Templates/Menu.html'
-    useBEM: false
+    useBEM: true
     Menu:
       namespace: nav
       wrapText: false
@@ -22,6 +69,33 @@ Carbon:
       filter: 'Neos.Neos:Document,!Carbon.Navigation:NotInMenu'
       showHome: false
       renderHiddenInIndex: false
+      renderClass:
+        list:
+          entryLevel: false
+          menuLevel: true
+        element:
+          entryLevel: false
+          menuLevel: true
+          subpages: true
+          isFirst: false
+          isLast: false
+          state:
+            normal: false
+            active: false
+            current: false
+        link:
+          entryLevel: false
+          menuLevel: true
+          subpages: false
+          isFirst: false
+          isLast: false
+          type: false
+          state:
+            normal: false
+            active: active
+            current:
+              - current
+              - active
     References:
       namespace: references
       wrapText: false
@@ -29,18 +103,45 @@ Carbon:
       elementTag: li
       maximumLevels: 1
       renderHiddenInIndex: true
+      renderClass:
+        link:
+          state:
+            current: current
+          type: true
     Breadcrumb:
       namespace: breadcrumb
       wrapText: false
       listTag: ol
       elementTag: li
       renderHiddenInIndex: false
-      sortDesc: true 
+      sortDesc: true
+      showHome: true
+      renderSiblings: false
+      renderPrevNext: false
+      filter: '[instanceof Neos.Neos:Document][!instanceof Carbon.Navigation:NotInMenu]'
+      renderClass:
+        link:
+          state:
+            active: active
+            current: current
     Dimensions:
       namespace: dimensions
       wrapText: false
       listTag: ul
       elementTag: li
       renderCurrent: true
+      useUriSegmentAsLabel: false
+      mulitipleDimensionDivider: ' - '
+      renderClass:
+        link:
+          dimension:
+            key: false
+            value: false
+          state:
+            normal: normal
+            current: current
+            absent:
+              - normal
+              - absent
     Redirect:
       statusCode: 301

--- a/README.md
+++ b/README.md
@@ -9,62 +9,69 @@
 
 This package provides various helps for implementing navigations in your Neos site.
 
-## NodeTypes
+# NodeTypes
 
 All Node Types are marked as abstract. So you have to include them as supertypes if you want to use them. You can read more about Node Type definition [here](https://neos.readthedocs.io/en/stable/CreatingASite/NodeTypes/NodeTypeDefinition.html).
 
-### `Carbon.Navigation:NotInMenu`
+## `Carbon.Navigation:NotInMenu`
 
 Hide the property `_hiddenInIndex`. Defined in [NodeTypes.NotInMenu.yaml](Configuration/NodeTypes.NotInMenu.yaml)
 
-### `Carbon.Navigation:HideSeo`
+## `Carbon.Navigation:HideSeo`
 
 Turn off all type of SEO properties. Defined in [NodeTypes.HideSeo.yaml](Configuration/NodeTypes.HideSeo.yaml)
 
-### `Carbon.Navigation:RedirectToParentPage`
+## `Carbon.Navigation:RedirectToParentPage`
 
 (Only in the live context) Redirect the user to the parent page. Defined in [NodeTypes.RedirectToParentPage.yaml](Configuration/NodeTypes.RedirectToParentPage.yaml) and [ToParentPage.fusion](Resources/Private/Fusion/Redirect/ToParentPage.fusion)
 
-### `Carbon.Navigation:RedirectToFirstChildPage`
+## `Carbon.Navigation:RedirectToFirstChildPage`
 
 (Only in the live context) Redirect the user to the first child page, if available. If not, the user gets redirected to the parent page. Defined in [NodeTypes.RedirectToFirstChildPage.yaml](Configuration/NodeTypes.RedirectToFirstChildPage.yaml) and [ToFirstChildPage.fusion](Resources/Private/Fusion/Redirect/ToFirstChildPage.fusion)
 
-### `Carbon.Navigation:References`
+## `Carbon.Navigation:References`
 
-Insert a property called `navigationreferences`. This is very useful if you want to create a navigation and want the editor to choose which documents should be included. However, you can also pass a custom collection to the Fusion prototype. Defined in [NodeTypes.References.yaml](Configuration/NodeTypes.References.yaml) and [References.fusion](Resources/Private/Fusion/References/References.fusion)
+Insert a property called `navigationreferences`. It is handy if you want to create a navigation and wants to let the editor to choose which documents should be included. However, you can also pass a custom collection to the Fusion prototype. Defined in [NodeTypes.References.yaml](Configuration/NodeTypes.References.yaml) and [References.fusion](Resources/Private/Fusion/References/References.fusion)
 
-## Menu Fusion prototypes
+# Menu Fusion prototypes
 
-You can edit the default behavior of each fusion prototype in your [Settings.yaml](Configuration/Settings.yaml). The configuration which can be set via Settings.yaml can also be set directly in the corresponding Fusion prototype. The Setting is here to provide an easy way to change some basics without writing Fusion code. The main difference to the default menus is that if you have no item to render, no markup at all gets rendered.
+You can edit the default behavior of each fusion prototype in your [Settings.yaml](Configuration/Settings.yaml). You can set the configuration via Settings.yaml or directly in the corresponding Fusion prototype. The Setting is here to provide an easy way to change some basics without writing Fusion code. If you don't have any entries, no markup at all gets rendered. No more empty `<ul>` anymore!
 
-### Properties for all menu prototypes
+## Properties for all menu prototypes
 
-| Property     | Description                                                                                                                                                       |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useBEM`     | (boolean) If set to `true`, the CSS classes get written in [BEM-Style](http://getbem.com). Defaults to `false`                                                    |
-| `namespace`  | (string) You can easily change the namespace of the navigation. Useful if you have multiple navigations on your page. Defaults to the name of the prototype       |
-| `wrapText`   | (boolean \|\| string) If `true`, the text inside the `a` gets wrapped with a `span`. If it is a string, this string will become the tag name. Defaults to `false` |
-| `listTag`    | The tag of the full navigation gets wrapped. If it set to `false`, the navigation gets no surrounding tag. Defaults to `'ul'`                                     |
-| `elementTag` | The tag a navigation entry gets wrapped. If it set to `false`, the entry gets no surrounding tag. Defaults to `'li'`                                              |
+| Property      | Description                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useBEM`      | (boolean) If set to `true`, the CSS classes get written in [BEM-Style](http://getbem.com). Defaults to `true`                                                      |
+| `namespace`   | (string) You can easily change the namespace of the navigation. Useful if you have multiple navigations on your page. Defaults to the name of the prototype        |
+| `wrapText`    | (boolean \|\| string) If `true`, the text inside the `a` gets wrapped with a `span`. If it is a string, this string will become the tag name. Defaults to `false`  |
+| `listTag`     | The tag of the full navigation gets wrapped. If it set to `false`, the navigation gets no surrounding tag. Defaults to `'ul'`                                      |
+| `elementTag`  | The tag a navigation entry gets wrapped. If it set to `false`, the entry gets no surrounding tag. Defaults to `'li'`                                               |
+| `beforeFirst` | (boolean \|\| string) If set, the string gets injected **before the first item**. The variables `item`, `iteration` and `entryLevel` are available.                |
+| `afterLast`   | (boolean \|\| string) If set, the string gets injected **after the last item**. The variables `item`, `iteration` and `entryLevel` are available.                  |
+| `beforeItem`  | (boolean \|\| string) If set, the string gets injected **before every item**. The variables `item`, `iteration` and `entryLevel` are available.                    |
+| `afterItem`   | (boolean \|\| string) If set, the string gets injected **after every item**. The variables `item`, `iteration` and `entryLevel` are available.                     |
+| `prependItem` | (boolean \|\| string) If set, the string gets injected **before every item inside the element**. The variables `item`, `iteration` and `entryLevel` are available. |
+| `appendItem`  | (boolean \|\| string) If set, the string gets injected **after every item inside the element**. The variables `item`, `iteration` and `entryLevel` are available.  |
+| `renderClass` | (array) The array which defines the css classes for the menu. Read more about this [here](#therenderclass)                                                         |
 
-### `Carbon.Navigation:Menu`
+### The renderClass
 
-Render a menu with items for nodes. Extends [Neos.Neos:Menu](https://neos.readthedocs.io/en/stable/References/NeosFusionReference.html#neos-neos-menu). Besides the [default properties](#propertiesforallmenuprototypes) following properties are available:
+The `renderClass` entry in the setting for each menu type defines the CSS classes for this particular menu. It has three subkeys: `list`, `element` and `link`. Everyone of this key as further entries. If the keys are set to `false`, this type of class gets not rendered.
 
-| Property              | Description                                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `maximumLevels`       | (integer) Restrict the maximum depth of items in the menu (relative to `entryLevel`) . Defaults to `2`                                              |
-| `filter`              | (string) Filter items by node type, defaults to `'Neos.Neos:Document,!Carbon.Navigation:NotInMenu'`                                                 |
-| `showHome`            | (boolean) If set to `true`, the homepage link gets rendererd in the menu. Done with `beforeFirst`. Defaults to `false`                              |
-| `entryLevel`          | (integer) Start the menu at the given depth. If no `startingPoint` is set, it is defaults to `1`, otherwise `0`                                     |
-| `startingPoint`       | (Node) The parent node of the first menu level                                                                                                      |
-| `lastLevel`           | (integer) Restrict the menu depth by node depth (relative to site node)                                                                             |
-| `renderHiddenInIndex` | (boolean) Whether nodes with `hiddenInIndex` should be rendered, defaults to `false`                                                                |
-| `itemCollection`      | (array) Explicitly set the Node items for the menu (alternative to `startingPoints` and levels)                                                     |
-| `beforeFirst`         | (boolean \|\| string) If set, the string gets injected **before the first item**. The variables `item`, `iteration` and `entryLevel` are available. |
-| `afterLast`           | (boolean \|\| string) If set, the string gets injected **after the last item**. The variables `item`, `iteration` and `entryLevel` are available.   |
-| `beforeItem`          | (boolean \|\| string) If set, the string gets injected **before every item**. The variables `item`, `iteration` and `entryLevel` are available.     |
-| `afterItem`           | (boolean \|\| string) If set, the string gets injected **after every item**. The variables `item`, `iteration` and `entryLevel` are available.      |
+| Key          | Description                                                                                                                                                                                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `entryLevel` | (boolean) Render a class with the entry level                                                                                                                                                                                                                |
+| `menuLevel`  | (boolean) Render a class with the menu level                                                                                                                                                                                                                 |
+| `subpages`   | (boolean) Render a class who indicate if the node has subpages (shown in the menu) or not                                                                                                                                                                    |
+| `isFirst`    | (boolean) Render a class who indicate the first item in the list                                                                                                                                                                                             |
+| `isLast`     | (boolean) Render a class who indicate the last item in the list                                                                                                                                                                                              |
+| `type`       | (boolean) Render a class who indicate which type of link is rendered                                                                                                                                                                                         |
+| `state`      | (array) Render classes who indicates which state (`normal`, `active`, `current` or `absent`) the node has. The values of the states can be `false`, a string or an array. If it is set to an array, the entry get multiple classes for this particular state |
+| `dimension`  | (array) Used only in the dimension menu. You can set if the dimension entry gets also a class with the dimension name (`key`) and/or the name with the uriPathSegment (`value`). Very useful if you want to use flags or icons in your dimension menu        |
+
+Look at [Settings.yaml](Configuration/Settings.yaml) for the default values for the different menu types
+
+### The variable `item`
 
 In the variable `item` are following properties available:
 
@@ -75,37 +82,62 @@ In the variable `item` are following properties available:
 | `item.state`        | (string) Menu state of the item: `'normal'`, `'current'` (the current node) or `'active'` (ancestor of current node) |
 | `item.label`        | (string) Full label of the node                                                                                      |
 | `item.menuLevel`    | (integer) Menu level the item is rendered on                                                                         |
-| `item.subItems`     | (array) The sub nodes from the current `item.node`. Useful to check if a page has subpages                           |
+| `item.subItems`     | (array) The sub-nodes from the current `item.node`. Useful to check if a page has subpages                           |
+
+## `Carbon.Navigation:Mixin`
+
+Basic Mixin for Menus. Extends [Neos.Neos:Menu](https://neos.readthedocs.io/en/stable/References/NeosFusionReference.html#neos-neos-menu).
+
+Defined in [Mixin.fusion](Resources/Private/Fusion/Menu/Mixin.fusion)
+
+## `Carbon.Navigation:Menu`
+
+Render a menu with items for nodes. Baes on `Carbon.Navigation:Mixin`. Besides the [default properties](#propertiesforallmenuprototypes) following properties are available:
+
+| Property              | Description                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `maximumLevels`       | (integer) Restrict the maximum depth of items in the menu (relative to `entryLevel`) . Defaults to `2`                 |
+| `filter`              | (string) Filter items by node type, defaults to `'Neos.Neos:Document,!Carbon.Navigation:NotInMenu'`                    |
+| `showHome`            | (boolean) If set to `true`, the homepage link gets rendererd in the menu. Done with `beforeFirst`. Defaults to `false` |
+| `entryLevel`          | (integer) Start the menu at the given depth. If no `startingPoint` is set, it is defaults to `1`, otherwise `0`        |
+| `startingPoint`       | (Node) The parent node of the first menu level                                                                         |
+| `lastLevel`           | (integer) Restrict the menu depth by node depth (relative to site node)                                                |
+| `renderHiddenInIndex` | (boolean) Whether nodes with `hiddenInIndex` should be rendered, defaults to `false`                                   |
+| `itemCollection`      | (array) Explicitly set the Node items for the menu (alternative to `startingPoints` and levels)                        |
 
 Defined in [Menu.fusion](Resources/Private/Fusion/Menu/Menu.fusion)
 
-### `Carbon.Navigation:References`
+## `Carbon.Navigation:References`
 
-Provides a list of links, based on nodes set in the inspector. Based on `Carbon.Navigation:Menu`. `itemCollection` is set to the closest instance of `Carbon.Navigation:References` who has the property `navigationreferences` set. `maximumLevels` defaults to `1` and `renderHiddenInIndex` defaults to `true`.
+Provides a list of links, based on nodes which are set in the inspector. Based on `Carbon.Navigation:Mixin`. `itemCollection` is set to the closest instance of `Carbon.Navigation:References` who has the property `navigationreferences` set. `maximumLevels` defaults to `1` and `renderHiddenInIndex` defaults to `true`.
 
 Defined in [References.fusion](Resources/Private/Fusion/Menu/References.fusion)
 
-### `Carbon.Navigation:Breadcrumb`
+## `Carbon.Navigation:Breadcrumb`
 
-Provides a breadcrumb navigation based on menu items. Based on `Carbon.Navigation:Menu`. `maximumLevels` is set to `1` and `listTag` defaults to `'ol'`.
+Provides a breadcrumb navigation based on the current node. Based on `Carbon.Navigation:Mixin`. `maximumLevels` is set to `1` and `listTag` defaults to `'ol'`.
 
-| Property   | Description                                                                        |
-| ---------- | ---------------------------------------------------------------------------------- |
-| `sortDesc` | (boolean) If set to `true` the sort order is set to descending. Defaults to `true` |
+| Property         | Description                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sortDesc`       | (boolean) If set to `true` the sort order is set to descending. Defaults to `true`                                                                                |
+| `renderSiblings` | (boolean) If set to `true` the siblings of a node gets rendered as a submenu. Defaults to `false`                                                                 |
+| `renderPrevNext` | (boolean) If set to `true` every entry get a submenu rendered with all previous and next nodes, including the active and current node itself. Defaults to `false` |
 
 Defined in [Breadcrumb.fusion](Resources/Private/Fusion/Menu/Breadcrumb.fusion)
 
-### `Carbon.Navigation:Dimensions`
+## `Carbon.Navigation:Dimensions`
 
-Create links to other node variants (e.g., variants of the current node in other dimensions) by using this Fusion object. Extends [Neos.Neos:DimensionsMenu](https://neos.readthedocs.io/en/stable/References/NeosFusionReference.html#neos-neos-dimensionsmenu).
+Create links to other node variants (e.g., variants of the current node in other dimensions) by using this Fusion object. Extends [Neos.Neos:DimensionsMenu](https://neos.readthedocs.io/en/stable/References/NeosFusionReference.html#neos-neos-dimensionsmenu). If no specific `dimension` is set, the `Neos.Neos:DimensionsMenu` prototype output the label from the node, and not the dimensions label. This prototype also fixes this wrong behavior.
 
-| Property              | Description                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------- |
-| `renderCurrent`       | (boolean) If set to `false` the current dimension didn't get rendered. Defaults to `true`           |
-| `dimension`           | (optional, string) name of the dimension which this menu should be based on. Example: `'language'`. |
-| `presets`             | (optional, array): If set, the presets rendered will be taken from this list of preset identifiers  |
-| `includeAllPresets`   | (boolean) If set to `true`, include all presets, not only allowed combinations. Defaults to `false` |
-| `renderHiddenInIndex` | (boolean) Whether nodes with hiddenInIndex should be rendered, defaults to `true`                   |
+| Property                    | Description                                                                                         |
+| --------------------------- | --------------------------------------------------------------------------------------------------- |
+| `renderCurrent`             | (boolean) If set to `false` the current dimension didn't get rendered. Defaults to `true`           |
+| `dimension`                 | (optional, string) name of the dimension which this menu should be based on. Example: `'language'`. |
+| `presets`                   | (optional, array): If set, the presets rendered will be taken from this list of preset identifiers  |
+| `includeAllPresets`         | (boolean) If set to `true`, include all presets, not only allowed combinations. Defaults to `false` |
+| `renderHiddenInIndex`       | (boolean) Whether nodes with hiddenInIndex should be rendered, defaults to `true`                   |
+| `useUriSegmentAsLabel`      | (boolean) If set to true, the uri segment will get used as label, defaults to `false`               |
+| `mulitipleDimensionDivider` | (string) String to divide multiple dimensions (if no specific `dimension` is set), defaults to `-`  |
 
 Defined in [Dimensions.fusion](Resources/Private/Fusion/Menu/Dimensions.fusion)
 

--- a/Resources/Private/Fusion/Internal/Class.fusion
+++ b/Resources/Private/Fusion/Internal/Class.fusion
@@ -11,38 +11,34 @@ prototype(Carbon.Navigation:Class) < prototype(Neos.Fusion:RawArray) {
     isFirst = ${iteration && iteration.isFirst}
     isLast = ${iteration && iteration.isLast}
     hasSubpages = ${item ? item.subItems ? true : false : null}
+    render = ${renderClass[this.name]}
 
-    @ignoreProperties = ${['name', 'pre', 'state', 'entryLevel', 'menuLevel', 'isFirst', 'isLast', 'hasSubpages']}
+    @ignoreProperties = ${['name', 'pre', 'state', 'entryLevel', 'menuLevel', 'isFirst', 'isLast', 'hasSubpages', 'render']}
     @context {
         pre = ${this.pre}
         name = ${this.name}
+        renderDimension = ${this.render.dimension}
+        renderState = ${this.render.state[this.state]}
     }
 
     namespaceClass = ${namespace + (useBEM ? '__' : '-') + this.name}
-    stateClass = ${this.name != 'list' && this.state ? this.pre + '-' + this.state : false}
-    entryLevelClass = ${this.entryLevel ? this.pre + '-entry' + this.entryLevel : false}
-    menuLevelClass = ${this.menuLevel ? this.pre + '-level' + this.menuLevel : false}
-    currentClass = ${this.state == 'current' ? this.pre + '-active' : false}
-
-    subpagesClass = ${this.name != 'list' && this.hasSubpages != null ? this.pre + (this.hasSubpages ? '-hassub' : '-nosub') : false}
-    isFirstClass = ${this.name != 'list' && this.isFirst ?  this.pre + '-first' : false }
-    isLastClass = ${this.name != 'list' && this.isLast ?  this.pre + '-last' : false }
-}
-
-prototype(Carbon.Navigation:Dimensions.Class) < prototype(Carbon.Navigation:Class) {
-    // THIS PROTOTYPE IS FOR INTERNAL USE ONLY.
-    // Properties can change without releasing a new major version.
-    // You have to be aware of this if you use this prototype directly
-
-    entryLevel = false
-    menuLevel = false
-    isFirst = false
-    isLast = false
-
-    absentClass = ${this.state == 'absent' ? '-normal' : false}
-    dimensionClass = Neos.Fusion:Collection {
-        @if.render = ${name != 'list'}
+    stateClass = Neos.Fusion:RawCollection {
+        collection = ${Type.isArray(renderState) ? renderState : Type.isString(renderState) ? [renderState] : []}
+        itemRenderer = ${pre + '-' + item}
+        @process.join = ${Array.join(value, ' ')}
+    }
+    entryLevelClass = ${this.render.entryLevel && this.entryLevel ? this.pre + '-entry' + this.entryLevel : false}
+    menuLevelClass = ${this.render.menuLevel && this.menuLevel ? this.pre + '-level' + this.menuLevel : false}
+    subpagesClass = ${this.render.subpages && this.hasSubpages != null ? this.pre + (this.hasSubpages ? '-hassub' : '-nosub') : false}
+    isFirstClass = ${this.render.isFirst && this.isFirst ?  this.pre + '-first' : false }
+    isLastClass = ${this.render.isLast && this.isLast ?  this.pre + '-last' : false }
+    dimension = Neos.Fusion:Collection {
+        @if.renderDimensions = ${renderDimension}
         collection = ${item.targetDimensions}
-        itemRenderer = ${pre + '-' + itemKey + ' ' + pre + '-' + itemKey + '-' + item.value}
+        itemRenderer = Neos.Fusion:RawArray {
+            key = ${renderDimension.key ? pre + '-' + itemKey : false}
+            value = ${renderDimension.value ? pre + '-' + itemKey + '-' + item.value : false}
+            @process.join = ${Array.join(value, ' ')}
+        }
     }
 }

--- a/Resources/Private/Fusion/Internal/Link.fusion
+++ b/Resources/Private/Fusion/Internal/Link.fusion
@@ -15,5 +15,6 @@ prototype(Carbon.Navigation:Link) < prototype(Carbon.Link:Link) {
 
     prototype(Carbon.Link:Class) {
         prepend = ${useBEM ? namespace + '__link-' : ''}
+        linkType.@if.renderTypeClass = ${renderClass.link.type}
     }
 }

--- a/Resources/Private/Fusion/Menu/Breadcrumb.fusion
+++ b/Resources/Private/Fusion/Menu/Breadcrumb.fusion
@@ -1,21 +1,58 @@
-prototype(Carbon.Navigation:Breadcrumb) < prototype(Carbon.Navigation:Menu) {
+prototype(Carbon.Navigation:Breadcrumb) < prototype(Carbon.Navigation:Mixin) {
     sortDesc = ${Configuration.setting('Carbon.Navigation.Breadcrumb.sortDesc')}
-    itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
-    itemCollection.@process.sort = ${this.sortDesc ? Array.reverse(value) : value}
+    showHome = ${Configuration.setting('Carbon.Navigation.Breadcrumb.showHome')}
 
-    useBEM = ${Configuration.setting('Carbon.Navigation.useBEM')}
+    itemCollection = ${q(node).add(q(node).parents('[instanceof Neos.Neos:Document]')).get()}
+    itemCollection.@process {
+        showHome = ${this.showHome ? value : Array.pop(value)}
+        sort = ${this.sortDesc ? Array.reverse(value) : value}
+    }
+
     namespace = ${Configuration.setting('Carbon.Navigation.Breadcrumb.namespace')}
     wrapText = ${Configuration.setting('Carbon.Navigation.Breadcrumb.wrapText')}
     listTag = ${Configuration.setting('Carbon.Navigation.Breadcrumb.listTag')}
     elementTag = ${Configuration.setting('Carbon.Navigation.Breadcrumb.elementTag')}
     renderHiddenInIndex = ${Configuration.setting('Carbon.Navigation.Breadcrumb.renderHiddenInIndex')}
-
-    beforeFirst = false
-    afterLast = false
-    beforeItem = false
-    afterItem = false
-
+    renderClass = ${Configuration.setting('Carbon.Navigation.Breadcrumb.renderClass')}
+    renderSiblings = ${Configuration.setting('Carbon.Navigation.Breadcrumb.renderSiblings')}
+    renderPrevNext = ${Configuration.setting('Carbon.Navigation.Breadcrumb.renderPrevNext')}
     maximumLevels = 1
+
+    @context {
+        renderSiblings = ${this.renderSiblings}
+        renderPrevNext = ${this.renderPrevNext}
+        renderHiddenInIndex = ${this.renderHiddenInIndex}
+    }
+
+    appendItem = Carbon.Navigation:Mixin {
+        @if.renderSiblings = ${renderPrevNext || renderSiblings}
+        itemCollection = Neos.Fusion:Case {
+            @context.filter = ${Configuration.setting('Carbon.Navigation.Breadcrumb.filter')}
+            prevNext {
+                condition = ${renderPrevNext}
+                renderer = Neos.Fusion:RawArray {
+                    prev = ${q(item.node).prevAll(filter).get()}
+                    node = ${item.node}
+                    next = ${q(item.node).nextAll(filter).get()}
+                    @process.extractSubElements = ${Carbon.Array.extractSubElements(value)}
+                }
+            }
+            siblings {
+                condition = true
+                renderer = ${q(item.node).siblings(filter).get()}
+            }
+        }
+
+        useBEM = ${useBEM}
+        namespace = ${namespace}
+        wrapText = ${wrapText}
+        listTag = ${listTag == 'ol' ? 'ul': listTag}
+        elementTag = ${elementTag}
+        renderHiddenInIndex = ${renderHiddenInIndex}
+        renderClass = ${renderClass}
+        maximumLevels = 1
+    }
+    link.@if.renderNotPrevNext = ${!renderPrevNext}
 
     @if.render = ${this.itemCollection && Type.isArray(this.itemCollection) && Array.length(this.itemCollection)}
 }

--- a/Resources/Private/Fusion/Menu/Dimensions.fusion
+++ b/Resources/Private/Fusion/Menu/Dimensions.fusion
@@ -5,33 +5,61 @@ prototype(Carbon.Navigation:Dimensions) < prototype(Neos.Neos:DimensionsMenu) {
     renderCurrent = ${Configuration.setting('Carbon.Navigation.Dimensions.renderCurrent')}
     listTag = ${Configuration.setting('Carbon.Navigation.Dimensions.listTag')}
     elementTag = ${Configuration.setting('Carbon.Navigation.Dimensions.elementTag')}
+    renderClass = ${Configuration.setting('Carbon.Navigation.Dimensions.renderClass')}
+    useUriSegmentAsLabel =  ${Configuration.setting('Carbon.Navigation.Dimensions.useUriSegmentAsLabel')}
+    mulitipleDimensionDivider = ${Configuration.setting('Carbon.Navigation.Dimensions.mulitipleDimensionDivider')}
 
     beforeFirst = false
     afterLast = false
     beforeItem = false
     afterItem = false
+    prependItem = false
+    appendItem = false
+
+    # name of the dimension to use (optional)
+    # dimension = 'language'
 
     @context {
         namespace = ${this.namespace}
         useBEM = ${this.useBEM}
         wrapText = ${this.wrapText}
+        renderClass = ${this.renderClass}
+        useUriSegmentAsLabel = ${this.useUriSegmentAsLabel}
+        dimension = ${this.dimension}
+        mulitipleDimensionDivider = ${this.mulitipleDimensionDivider}
     }
 
     renderItem = ${renderCurrent ? true : item.state != 'current'}
     link = Carbon.Navigation:Link {
-        additionalClass = Carbon.Navigation:Dimensions.Class {
+        content = Neos.Fusion:Case {
+            hasSingleDimension {
+                condition = ${dimension}
+                renderer = ${useUriSegmentAsLabel ? item.targetDimensions[dimension].value : item.label}
+            }
+            multipleDimension {
+                condition = true
+                renderer = Neos.Fusion:RawCollection {
+                    collection = ${item.targetDimensions}
+                    itemName = 'dimension'
+                    itemRenderer = ${useUriSegmentAsLabel ? dimension.value : dimension.label}
+                    @process.join = ${Array.join(value, mulitipleDimensionDivider)}
+                }
+            }
+        }
+
+        additionalClass = Carbon.Navigation:Class {
             name = 'link'
         }
     }
 
     list.attributes = Neos.Fusion:Attributes {
-        class = Carbon.Navigation:Dimensions.Class {
+        class = Carbon.Navigation:Class {
             name = 'list'
         }
     }
 
     element.attributes = Neos.Fusion:Attributes {
-        class = Carbon.Navigation:Dimensions.Class {
+        class = Carbon.Navigation:Class {
             name = 'element'
         }
     }

--- a/Resources/Private/Fusion/Menu/Menu.fusion
+++ b/Resources/Private/Fusion/Menu/Menu.fusion
@@ -1,10 +1,9 @@
-prototype(Carbon.Navigation:Menu) < prototype(Neos.Neos:Menu) {
+prototype(Carbon.Navigation:Menu) < prototype(Carbon.Navigation:Mixin) {
     // The properties of an item is available under following variables
     // - item.menuLevel
     // - item.subItems
     // - item.state
 
-    useBEM = ${Configuration.setting('Carbon.Navigation.useBEM')}
     namespace = ${Configuration.setting('Carbon.Navigation.Menu.namespace')}
     wrapText = ${Configuration.setting('Carbon.Navigation.Menu.wrapText')}
     listTag = ${Configuration.setting('Carbon.Navigation.Menu.listTag')}
@@ -16,6 +15,8 @@ prototype(Carbon.Navigation:Menu) < prototype(Neos.Neos:Menu) {
     renderHiddenInIndex = ${Configuration.setting('Carbon.Navigation.Menu.renderHiddenInIndex')}
     entryLevel = ${this.startingPoint ? 0 : 1}
 
+    renderClass = ${Configuration.setting('Carbon.Navigation.Menu.renderClass')}
+
     prototype(Carbon.Navigation:Class) {
         isFirst = ${showHome ? false : iteration && iteration.isFirst}
     }
@@ -23,6 +24,7 @@ prototype(Carbon.Navigation:Menu) < prototype(Neos.Neos:Menu) {
     beforeFirst = Carbon.Navigation:Link {
         @if.weAreOnTheMainLevel = ${showHome && item.menuLevel == entryLevel}
         node = ${site}
+        content = ${q(site).property('title')}
 
         prototype(Carbon.Navigation:Class) {
             isFirst = true
@@ -43,41 +45,4 @@ prototype(Carbon.Navigation:Menu) < prototype(Neos.Neos:Menu) {
             content = ${value}
         }
     }
-    afterLast = false
-    beforeItem = false
-    afterItem = false
-
-    @context {
-        namespace = ${this.namespace}
-        useBEM = ${this.useBEM}
-        wrapText = ${this.wrapText}
-        showHome = ${this.showHome}
-        elementTag = ${this.elementTag}
-    }
-
-    link = Carbon.Navigation:Link {
-        additionalClass = Carbon.Navigation:Class {
-            name = 'link'
-        }
-    }
-
-    list.attributes = Neos.Fusion:Attributes {
-        class = Carbon.Navigation:Class {
-            name = 'list'
-        }
-    }
-
-    element.attributes = Neos.Fusion:Attributes {
-        class = Carbon.Navigation:Class {
-            name = 'element'
-        }
-    }
-
-    # if Carbon.Hypen is available, always replace shy
-     @process.shy = Neos.Fusion:Value {
-        @if.carbonHypenIsInstalled = ${Configuration.setting('Neos.Neos.fusion.autoInclude')['Carbon.Hyphen']}
-        value = Carbon.Hyphen:Shy.AlwaysReplace
-    }
-    templatePath = ${Configuration.setting('Carbon.Navigation.templatePath')}
-    sectionName = 'Menu'
 }

--- a/Resources/Private/Fusion/Menu/Mixin.fusion
+++ b/Resources/Private/Fusion/Menu/Mixin.fusion
@@ -1,0 +1,46 @@
+prototype(Carbon.Navigation:Mixin) < prototype(Neos.Neos:Menu) {
+    useBEM = ${Configuration.setting('Carbon.Navigation.useBEM')}
+
+    beforeFirst = false
+    afterLast = false
+    beforeItem = false
+    afterItem = false
+    prependItem = false
+    appendItem = false
+
+    @context {
+        namespace = ${this.namespace}
+        useBEM = ${this.useBEM}
+        wrapText = ${this.wrapText}
+        showHome = ${this.showHome}
+        listTag = ${this.listTag}
+        elementTag = ${this.elementTag}
+        renderClass = ${this.renderClass}
+    }
+
+    link = Carbon.Navigation:Link {
+        additionalClass = Carbon.Navigation:Class {
+            name = 'link'
+        }
+    }
+
+    list.attributes = Neos.Fusion:Attributes {
+        class = Carbon.Navigation:Class {
+            name = 'list'
+        }
+    }
+
+    element.attributes = Neos.Fusion:Attributes {
+        class = Carbon.Navigation:Class {
+            name = 'element'
+        }
+    }
+
+    # if Carbon.Hypen is available, always replace shy
+     @process.shy = Neos.Fusion:Value {
+        @if.carbonHypenIsInstalled = ${Configuration.setting('Neos.Neos.fusion.autoInclude')['Carbon.Hyphen']}
+        value = Carbon.Hyphen:Shy.AlwaysReplace
+    }
+    templatePath = ${Configuration.setting('Carbon.Navigation.templatePath')}
+    sectionName = 'Menu'
+}

--- a/Resources/Private/Fusion/Menu/References.fusion
+++ b/Resources/Private/Fusion/Menu/References.fusion
@@ -1,18 +1,14 @@
-prototype(Carbon.Navigation:References) < prototype(Carbon.Navigation:Menu) {
+prototype(Carbon.Navigation:References) < prototype(Carbon.Navigation:Mixin) {
     itemCollection = ${q(node).closest('[instanceof Carbon.Navigation:References][navigationreferences]').property('navigationreferences')}
 
-    useBEM = ${Configuration.setting('Carbon.Navigation.useBEM')}
     namespace = ${Configuration.setting('Carbon.Navigation.References.namespace')}
     wrapText = ${Configuration.setting('Carbon.Navigation.References.wrapText')}
     listTag = ${Configuration.setting('Carbon.Navigation.References.listTag')}
     elementTag = ${Configuration.setting('Carbon.Navigation.References.elementTag')}
     maximumLevels = ${Configuration.setting('Carbon.Navigation.References.maximumLevels')}
     renderHiddenInIndex = ${Configuration.setting('Carbon.Navigation.References.renderHiddenInIndex')}
+    renderClass = ${Configuration.setting('Carbon.Navigation.References.renderClass')}
 
-    beforeFirst = false
-    afterLast = false
-    beforeItem = false
-    afterItem = false
 
     @if.render = ${this.itemCollection && Type.isArray(this.itemCollection) && Array.length(this.itemCollection)}
 }

--- a/Resources/Private/Templates/Menu.html
+++ b/Resources/Private/Templates/Menu.html
@@ -31,8 +31,10 @@
 <f:section name="ListElement">
     {fusion:render(path:'beforeItem', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}
     <f:if condition="{elementTag}"><{elementTag}{fusion:render(path:'element.attributes', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}></f:if>
+        {fusion:render(path:'prependItem', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}
         {fusion:render(path:'link', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}
         {content -> f:format.raw()}
+        {fusion:render(path:'appendItem', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}
     <f:if condition="{elementTag}"></{elementTag}></f:if>
     {fusion:render(path:'afterItem', context: {item: item, iteration: iteration, entryLevel: entryLevel}) -> f:format.raw()}
 </f:section>

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,18 @@
     "type": "neos-carbon",
     "description": "Navigation and frontend redirect helper for Neos CMS",
     "license": "MIT",
-    "keywords": ["flow", "neos", "fusion", "helper", "redirect", "navigation", "carbon"],
+    "keywords": [
+        "flow",
+        "neos",
+        "fusion",
+        "helper",
+        "redirect",
+        "navigation",
+        "carbon"
+    ],
     "require": {
         "neos/neos": "~3.0 || ~4.0",
+        "carbon/eel": "^1.1",
         "carbon/link": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
✨ Set the CSS classes via Settings.yaml => much less unneeded classes in the frontend
:sparkles: The breadcrumb now also can render the siblings of the active node
:bug: Fix wrong label behaviour in the Dimensions Menu
 